### PR TITLE
Created new configuration for just the Aglais Public examples

### DIFF
--- a/config/notebooks/notebooks-public.json
+++ b/config/notebooks/notebooks-public.json
@@ -1,0 +1,29 @@
+{
+"notebooks" : [
+           {
+              "name" : "SetUp",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/SetUp.json",
+              "totaltime" : 45,
+              "results" : []
+           },
+           {
+              "name" : "Mean_proper_motions_over_the_sky",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
+              "totaltime" : 55,
+              "results" : []
+           },
+           {
+              "name" : "Source_counts_over_the_sky.json",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Source_counts_over_the_sky.json",
+              "totaltime" : 22,
+              "results" : []
+           },
+           {
+              "name" : "Good_astrometric_solutions_via_ML_Random_Forrest_classifier",
+              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Good_astrometric_solutions_via_ML_Random_Forrest_classifier.json",
+              "totaltime" : 500,
+              "results" : []
+           }
+
+]
+}


### PR DESCRIPTION
The notebooks.json configuration runs all of the public examples as well as dcr's noteboosk, which take several hours to complete.
I've added another configuration for just the public examples, for cases where we just want a quicker test.