### PR TITLE
Feature/add delays

### DIFF
--- a/aglais_benchmark/aglais_benchmark.py
+++ b/aglais_benchmark/aglais_benchmark.py
@@ -101,7 +101,20 @@ class AglaisBenchmarker(object):
             data["name"] = tmpfile
             with open(tmpfile, 'w+') as cred:
                 json.dump(data, cred)
+        except Exception as e:
+            logging.exception(e)
 
+        try:
+            # Make notebook
+            batcmd="zdairi --config " + config + " notebook create --filepath " + tmpfile
+            pipe = subprocess.Popen(batcmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+            result = pipe.communicate()[0]
+            result = result.decode().split("\n")
+            text = result[0]
+            notebookid = text.split(": ")[1]
+        except Exception as e:
+            # Try again
+            # Temorary fix
             # Make notebook
             batcmd="zdairi --config " + config + " notebook create --filepath " + tmpfile
             pipe = subprocess.Popen(batcmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
@@ -110,6 +123,7 @@ class AglaisBenchmarker(object):
             text = result[0]
             notebookid = text.split(": ")[1]
 
+        try:
             # Run notebook
             batcmd="zdairi --config " + config + " notebook run --notebook " + notebookid
             pipe = subprocess.Popen(batcmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)


### PR DESCRIPTION
Added optional delays to the benchmark run.
Delays can be added (in seconds) to the start of the run, or before each notebook.
Due to the way the tests are run (in parallel with the multiprocessing lib), the only way I could get this working for now, is to make the start delay = delay_input * user_number (1, 2,3..)
So this means the delay would increase for a given delay input of 10 sec as: 0, 10 seconds, 20 seconds ...